### PR TITLE
Add Telem Incident Feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,16 @@ It is a collection of awesome software, libraries, documents, books, resources, 
 Thanks to all [contributors](https://github.com/fabionoth/awesome-web3-security/graphs/contributors). You're awesome. This wouldn't be possible without you! The goal is to build a categorized, community-driven collection of very well-known resources.
 
 List links and description 
-[Tools]
+* **[Tools](#tools)**
+  * [Forensics](#forensics)
+  * [Testing](#testing)
 
-## Tools
-### Forensics
+## <a name="tools"></a> Tools
+### <a name="forensics"> Forensics
 * [abi-decompiler](https://github.com/Decurity/abi-decompiler) - The purpose of abi-decompiler is to implement a simple tools to recover ABI of EVM smart contracts, including function names.
 * [DeDaub](https://app.dedaub.com/decompile) - The Dedaub decompiler takes Ethereum Virtual Machine (EVM) bytecode and produces more readable Solidity-like code.
 * [Panoramix](https://github.com/palkeo/panoramix) -This is an EVM decompiler.
-### Testing
+### <a name="testing"> Testing
 * [BSCheck](https://bscheck.eu/) - Free Binance Smart Chain token analyzer
 * [QuillCheck](https://check.quillai.network/) - Safeguard your web3 investments with our AI Agent. Uncover honeypots, understand token permissions, and get comprehensive market insights. Shield yourself from rugpulls and scam tokens. DYOR here!
 * [Rugscreen](https://rugscreen.com/) - Catches rugpulls before you lose money.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# awesome-web3-security

--- a/README.md
+++ b/README.md
@@ -20,6 +20,6 @@ List links and description
 ## CTF
 ## Playgrounds
 ## Genesys Blocks
-##Standarts
+## Standarts
 ## Databases
 ## Web3Auditors Companies

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ List links and description
 ## <a name="playgrounds"> Playgrounds
 * [Remix Ethereum](https://remix.ethereum.org/) - No more words. Everybody knows Remix
 * [Rust Playground](https://play.rust-lang.org/) - The Rust Playground
+* [TON Network Playground](https://ide.ton.org/) - TON Network IDE
 ## <a name="standards"> Standards
 * [ERC 20](https://ethereum.org/en/developers/docs/standards/tokens/erc-20/) - The ERC-20 introduces a standard for Fungible Tokens, in other words, they have a property that makes each Token be exactly the same (in type and value) as another Token.
 * [OWASP Smart Contract](https://owasp.org/www-project-smart-contract-top-10/) - The OWASP Smart Contract Top 10 is a standard awareness document that intends to provide Web3 developers and security teams with insight into the top 10 vulnerabilities found in smart contracts.

--- a/README.md
+++ b/README.md
@@ -60,4 +60,3 @@ List links and description
 ## Databases
 * [Chainlist](https://chainlist.org/) - Helping users connect to EVM powered networks
 * [REKT](https://rekt.news/leaderboard/) - Rekt News is a leading online platform offering timely and concise information on decentralized finance (DeFi), blockchain, and the cryptocurrency industry
-## Web3Auditors Companies

--- a/README.md
+++ b/README.md
@@ -20,10 +20,22 @@ List links and description
 * [QuillCheck](https://check.quillai.network/) - Safeguard your web3 investments with our AI Agent. Uncover honeypots, understand token permissions, and get comprehensive market insights. Shield yourself from rugpulls and scam tokens. DYOR here!
 * [Rugscreen](https://rugscreen.com/) - Catches rugpulls before you lose money.
 * [TokenSniffer](https://tokensniffer.com/) - Automated scam detection, auditing, and metrics
+### SAST/DAST/Unity Test Analisys
+* [Truffle Suite](https://archive.trufflesuite.com/) - The most comprehensive suite of tools for smart contract development
+* [Brownie](https://eth-brownie.readthedocs.io/en/stable/) - Brownie is a Python-based development and testing framework for smart contracts targeting the Ethereum Virtual Machine.
+* [Hardhat](https://hardhat.org/) - Hardhat is a development environment for Ethereum software
+* [Foundry](https://github.com/foundry-rs/foundry) - Foundry is a blazing fast, portable and modular toolkit for Ethereum application development written in Rust.
+* [Slither](https://github.com/crytic/slither) - Slither is a Solidity & Vyper static analysis framework written in Python3
+* [SmartCheck](https://github.com/smartdec/smartcheck) - SmartCheck is an extensible static analysis tool for discovering vulnerabilities and other code issues in Ethereum smart contracts written in the Solidity programming language.
+* [Mythril](https://github.com/ConsenSys/mythril) - Mythril is a security analysis tool for EVM bytecode
+* [Mythx](https://mythx.io/) - Create a MythX account, link your Ethereum address, and generate API keys
+* [Security2](https://github.com/eth-sri/securify2) - Securify 2.0 is a security scanner for Ethereum smart contracts supported by the Ethereum Foundation and ChainSecurity.
+* [Ethereum Security Box](https://github.com/trailofbits/eth-security-toolbox) - This repository contains scripts to create a Docker container preinstalled and preconfigured with all of Trail of Bits’ Ethereum security tools.
+* [Manticore](https://github.com/trailofbits/manticore) - Manticore is a symbolic execution tool for the analysis of smart contracts and binaries.
+* [Octopus](https://github.com/FuzzingLabs/octopus) - Octopus is a security analysis framework for WebAssembly module and Blockchain Smart Contract.
 ### Other tools
 * [ETH-Toolbox](https://eth-toolbox.com/) - EthToolbox v1.1 is a set of useful tools for Ethereum developers.
-* 
-### SAST Analysis
+* [dethcode](https://github.com/dethcrypto/dethcode) - View source of deployed Ethereum smart contracts in VS Code
 ### OS
 * [ZIION](https://www.ziion.org/) - ZIION is the first open-source, end-to-end, pre-compiled, multi-architecture, multi-protocol blockchain security testing and development solution
 ### Unity Testing

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 
-A collection of awesome software, libraries, documents, books, resources, and cool stuff about **web3** security.
+It is a collection of awesome software, libraries, documents, books, resources, and cool stuff about **web3** security.
 
 Thanks to all [contributors](https://github.com/fabionoth/awesome-web3-security/graphs/contributors). You're awesome. This wouldn't be possible without you! The goal is to build a categorized, community-driven collection of very well-known resources.
 
@@ -11,7 +11,7 @@ List links and description
 
 ## Tools
 ### Forensics
-### SAST Analisys
+### SAST Analysis
 ### OS
 ### Unity Testing
 ### Fuzzers
@@ -20,6 +20,6 @@ List links and description
 ## CTF
 ## Playgrounds
 ## Genesys Blocks
-## Standarts
+## Standards
 ## Databases
 ## Web3Auditors Companies

--- a/README.md
+++ b/README.md
@@ -10,36 +10,36 @@ List links and description
 
 ## Tools
 ### Forensics
-* [DeDaub](https://app.dedaub.com/decompile) - The Dedaub decompiler takes Ethereum Virtual Machine (EVM) bytecode and produces more readable Solidity-like code.
 * [abi-decompiler](https://github.com/Decurity/abi-decompiler) - The purpose of abi-decompiler is to implement a simple tools to recover ABI of EVM smart contracts, including function names.
+* [DeDaub](https://app.dedaub.com/decompile) - The Dedaub decompiler takes Ethereum Virtual Machine (EVM) bytecode and produces more readable Solidity-like code.
 * [Panoramix](https://github.com/palkeo/panoramix) -This is an EVM decompiler.
 ### Testing
 * [BSCheck](https://bscheck.eu/) - Free Binance Smart Chain token analyzer
-* [Rug PUll Detector](http://rugpulldetector.com/) - Find the smart contract of the token and copy solidity code
 * [QuillCheck](https://check.quillai.network/) - Safeguard your web3 investments with our AI Agent. Uncover honeypots, understand token permissions, and get comprehensive market insights. Shield yourself from rugpulls and scam tokens. DYOR here!
 * [Rugscreen](https://rugscreen.com/) - Catches rugpulls before you lose money.
 * [TokenSniffer](https://tokensniffer.com/) - Automated scam detection, auditing, and metrics
+* [Rug PUll Detector](http://rugpulldetector.com/) - Find the smart contract of the token and copy solidity code
 ### SAST/DAST/Unity Test Analisys
-* [Truffle Suite](https://archive.trufflesuite.com/) - The most comprehensive suite of tools for smart contract development
 * [Brownie](https://eth-brownie.readthedocs.io/en/stable/) - Brownie is a Python-based development and testing framework for smart contracts targeting the Ethereum Virtual Machine.
-* [Hardhat](https://hardhat.org/) - Hardhat is a development environment for Ethereum software
+* [Ethereum Security Box](https://github.com/trailofbits/eth-security-toolbox) - This repository contains scripts to create a Docker container preinstalled and preconfigured with all of Trail of Bits’ Ethereum security tools.
 * [Foundry](https://github.com/foundry-rs/foundry) - Foundry is a blazing fast, portable and modular toolkit for Ethereum application development written in Rust.
+* [Hardhat](https://hardhat.org/) - Hardhat is a development environment for Ethereum software
+* [Manticore](https://github.com/trailofbits/manticore) - Manticore is a symbolic execution tool for the analysis of smart contracts and binaries.
+* [Mythril](https://github.com/ConsenSys/mythril) - Mythril is a security analysis tool for EVM bytecode
+* [Mythx](https://mythx.io/) - Create a MythX account, link your Ethereum address, and generate API keys
+* [Octopus](https://github.com/FuzzingLabs/octopus) - Octopus is a security analysis framework for WebAssembly module and Blockchain Smart Contract.
 * [Scribble](https://github.com/ConsenSys/scribble) - A Solidity runtime verification tool for property-based testing.
+* [Security2](https://github.com/eth-sri/securify2) - Securify 2.0 is a security scanner for Ethereum smart contracts supported by the Ethereum Foundation and ChainSecurity.
 * [Slither](https://github.com/crytic/slither) - Slither is a Solidity & Vyper static analysis framework written in Python3
 * [Surya](https://github.com/ConsenSys/surya) - Surya is an utility tool for smart contract systems. It provides a number of visual outputs and information about the contracts' structure.
 * [SmartCheck](https://github.com/smartdec/smartcheck) - SmartCheck is an extensible static analysis tool for discovering vulnerabilities and other code issues in Ethereum smart contracts written in the Solidity programming language.
-* [Mythril](https://github.com/ConsenSys/mythril) - Mythril is a security analysis tool for EVM bytecode
-* [Mythx](https://mythx.io/) - Create a MythX account, link your Ethereum address, and generate API keys
-* [Security2](https://github.com/eth-sri/securify2) - Securify 2.0 is a security scanner for Ethereum smart contracts supported by the Ethereum Foundation and ChainSecurity.
-* [Ethereum Security Box](https://github.com/trailofbits/eth-security-toolbox) - This repository contains scripts to create a Docker container preinstalled and preconfigured with all of Trail of Bits’ Ethereum security tools.
-* [Manticore](https://github.com/trailofbits/manticore) - Manticore is a symbolic execution tool for the analysis of smart contracts and binaries.
-* [Octopus](https://github.com/FuzzingLabs/octopus) - Octopus is a security analysis framework for WebAssembly module and Blockchain Smart Contract.
+* [Truffle Suite](https://archive.trufflesuite.com/) - The most comprehensive suite of tools for smart contract development
 ### OS
 * [ZIION](https://www.ziion.org/) - ZIION is the first open-source, end-to-end, pre-compiled, multi-architecture, multi-protocol blockchain security testing and development solution
 ### Fuzzers
+* [ChainFuzz](https://github.com/ChainSecurity/ChainFuzz) - ChainFuzz requires a truffle project with correct migration files to fuzz a project.
 * [Echidna](https://github.com/crytic/echidna) - Echidna is a Haskell program designed for fuzzing/property-based testing of Ethereum smart contracts.
 * [Foundry](https://github.com/foundry-rs/foundry) - Foundry is a blazing fast, portable and modular toolkit for Ethereum application development written in Rust.
-* [ChainFuzz](https://github.com/ChainSecurity/ChainFuzz) - ChainFuzz requires a truffle project with correct migration files to fuzz a project.
 ### Other tools
 * [ETH-Toolbox](https://eth-toolbox.com/) - EthToolbox v1.1 is a set of useful tools for Ethereum developers.
 * [dethcode](https://github.com/dethcrypto/dethcode) - View source of deployed Ethereum smart contracts in VS Code
@@ -47,11 +47,11 @@ List links and description
 * [Hacken Proof](https://hackenproof.com/) - Expert web3 bug bounty and crowdsourced audit platform
 * [Immunefi](https://immunefi.com/) - Web3's bug bounty platform
 ## CTF
-* [Damn Vulnerable DeFi](https://www.damnvulnerabledefi.xyz/) - The training ground for security researchers, developers and educators to dive into smart contract security.
 * [blocksec-ctfs](https://github.com/blockthreat/blocksec-ctfs) - A curated list of blockchain security Wargames, Challenges, and Capture the Flag (CTF) competitions and solution writeups.
-* [The Ethernaut](https://ethernaut.openzeppelin.com/) - The Ethernaut is a Web3/Solidity based wargame inspired by overthewire.org
 * [Capture the Ether](https://capturetheether.com/) - the game of Ethereum smart contract security
 * [ciphershastra](https://ciphershastra.com/) - A place where you can enhance your Security Skills by solving and learning from CTF-like challenges.
+* [Damn Vulnerable DeFi](https://www.damnvulnerabledefi.xyz/) - The training ground for security researchers, developers and educators to dive into smart contract security.
+* [The Ethernaut](https://ethernaut.openzeppelin.com/) - The Ethernaut is a Web3/Solidity based wargame inspired by overthewire.org
 ## Playgrounds
 * [Remix Ethereum](https://remix.ethereum.org/) - No more words.Everybody knows Remix 
 ## Standards

--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ List links and description
 * [DeDaub](https://app.dedaub.com/decompile) - The Dedaub decompiler takes Ethereum Virtual Machine (EVM) bytecode and produces more readable Solidity-like code.
 * [abi-decompiler](https://github.com/Decurity/abi-decompiler) - The purpose of abi-decompiler is to implement a simple tools to recover ABI of EVM smart contracts, including function names.
 * [Panoramix](https://github.com/palkeo/panoramix) -This is an EVM decompiler.
+### Testing
+* [BSCheck](https://bscheck.eu/) - Free Binance Smart Chain token analyzer
+* [Rug PUll Detector](http://rugpulldetector.com/) - Find the smart contract of the token and copy solidity code
+* [QuillCheck](https://check.quillai.network/) - Safeguard your web3 investments with our AI Agent. Uncover honeypots, understand token permissions, and get comprehensive market insights. Shield yourself from rugpulls and scam tokens. DYOR here!
+* [Rugscreen](https://rugscreen.com/) - Catches rugpulls before you lose money.
+* [TokenSniffer](https://tokensniffer.com/) - Automated scam detection, auditing, and metrics
+### Other tools
+* [ETH-Toolbox](https://eth-toolbox.com/) - EthToolbox v1.1 is a set of useful tools for Ethereum developers.
+* 
 ### SAST Analysis
 ### OS
 * [ZIION](https://www.ziion.org/) - ZIION is the first open-source, end-to-end, pre-compiled, multi-architecture, multi-protocol blockchain security testing and development solution

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ List links and description
 * [Manticore](https://github.com/trailofbits/manticore) - Manticore is a symbolic execution tool for the analysis of smart contracts and binaries.
 * [Mythril](https://github.com/ConsenSys/mythril) - Mythril is a security analysis tool for EVM bytecode
 * [Mythx](https://mythx.io/) - Create a MythX account, link your Ethereum address, and generate API keys
+* [Olympix](https://github.com/olympix) - Scanning for vulnerabilities, or automating test generation. 
 * [Octopus](https://github.com/FuzzingLabs/octopus) - Octopus is a security analysis framework for WebAssembly module and Blockchain Smart Contract.
 * [Scribble](https://github.com/ConsenSys/scribble) - A Solidity runtime verification tool for property-based testing.
 * [Security2](https://github.com/eth-sri/securify2) - Securify 2.0 is a security scanner for Ethereum smart contracts supported by the Ethereum Foundation and ChainSecurity.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ It is a collection of awesome software, libraries, documents, books, resources, 
 Thanks to all [contributors](https://github.com/fabionoth/awesome-web3-security/graphs/contributors). You're awesome. This wouldn't be possible without you! The goal is to build a categorized, community-driven collection of very well-known resources.
 
 List links and description 
+[Tools]
 
 ## Tools
 ### Forensics
@@ -57,6 +58,8 @@ List links and description
 ## Standards
 * [ERC 20](https://ethereum.org/en/developers/docs/standards/tokens/erc-20/) - The ERC-20 introduces a standard for Fungible Tokens, in other words, they have a property that makes each Token be exactly the same (in type and value) as another Token.
 * [OWASP Smart Contract](https://owasp.org/www-project-smart-contract-top-10/) - The OWASP Smart Contract Top 10 is a standard awareness document that intends to provide Web3 developers and security teams with insight into the top 10 vulnerabilities found in smart contracts.
-## Databases
+## Databases/Books and References
 * [Chainlist](https://chainlist.org/) - Helping users connect to EVM powered networks
 * [REKT](https://rekt.news/leaderboard/) - Rekt News is a leading online platform offering timely and concise information on decentralized finance (DeFi), blockchain, and the cryptocurrency industry
+* [Smart Contract Security Chapter](https://github.com/ethereumbook/ethereumbook/blob/develop/09smart-contracts-security.asciidoc) - Chapter 9 from Ethereum book.
+

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ List links and description
 * [Capture the Ether](https://capturetheether.com/) - the game of Ethereum smart contract security
 * [ciphershastra](https://ciphershastra.com/) - A place where you can enhance your Security Skills by solving and learning from CTF-like challenges.
 * [Damn Vulnerable DeFi](https://www.damnvulnerabledefi.xyz/) - The training ground for security researchers, developers and educators to dive into smart contract security.
+* [Hack the TON](https://www.hacktheton.com/) - Hack the TON is a TON based wargame inspired by The Ethernaut, played in the TON Virtual Machine.
 * [The Ethernaut](https://ethernaut.openzeppelin.com/) - The Ethernaut is a Web3/Solidity based wargame inspired by overthewire.org
 ## <a name="playgrounds"> Playgrounds
 * [Remix Ethereum](https://remix.ethereum.org/) - No more words. Everybody knows Remix

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ List links and description
 ### <a name="others"> Other tools
 * [ETH-Toolbox](https://eth-toolbox.com/) - EthToolbox v1.1 is a set of useful tools for Ethereum developers.
 * [dethcode](https://github.com/dethcrypto/dethcode) - View source of deployed Ethereum smart contracts in VS Code
+* [GetBlock](https://getblock.io/) - a Blockchain-as-a-Service (BaaS) platform that provides a fast and easy API connection to RPC full nodes for 50+ blockchains.
 ## <a name="bugbounty"> BugBounty
 * [Hacken Proof](https://hackenproof.com/) - Expert web3 bug bounty and crowdsourced audit platform
 * [Immunefi](https://immunefi.com/) - Web3's bug bounty platform

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# awesome-web3-security
+# Awesome Web3 Security
+
+[![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
+
+A collection of awesome software, libraries, documents, books, resources, and cool stuff about **web3** security.
+
+Thanks to all [contributors](https://github.com/fabionoth/awesome-web3-security/graphs/contributors). You're awesome. This wouldn't be possible without you! The goal is to build a categorized, community-driven collection of very well-known resources.
+
+
+List links and description 
+
+## Tools
+### Forensics
+### SAST Analisys
+### OS
+### Unity Testing
+### Fuzzers
+### Extensions and Formatters
+## BugBounty
+## CTF
+## Playgrounds
+## Genesys Blocks
+##Standarts
+## Databases
+## Web3Auditors Companies

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ List links and description
 * [ETH-Toolbox](https://eth-toolbox.com/) - EthToolbox v1.1 is a set of useful tools for Ethereum developers.
 * [dethcode](https://github.com/dethcrypto/dethcode) - View source of deployed Ethereum smart contracts in VS Code
 ## BugBounty
+* [Hacken Proof](https://hackenproof.com/) - Expert web3 bug bounty and crowdsourced audit platform
+* [Immunefi](https://immunefi.com/) - Web3's bug bounty platform
 ## CTF
 * [Damn Vulnerable DeFi](https://www.damnvulnerabledefi.xyz/) - The training ground for security researchers, developers and educators to dive into smart contract security.
 * [blocksec-ctfs](https://github.com/blockthreat/blocksec-ctfs) - A curated list of blockchain security Wargames, Challenges, and Capture the Flag (CTF) competitions and solution writeups.
@@ -54,5 +56,6 @@ List links and description
 * [ERC 20](https://ethereum.org/en/developers/docs/standards/tokens/erc-20/) - The ERC-20 introduces a standard for Fungible Tokens, in other words, they have a property that makes each Token be exactly the same (in type and value) as another Token.
 * [OWASP Smart Contract](https://owasp.org/www-project-smart-contract-top-10/) - The OWASP Smart Contract Top 10 is a standard awareness document that intends to provide Web3 developers and security teams with insight into the top 10 vulnerabilities found in smart contracts.
 ## Databases
+* [Chainlist](https://chainlist.org/) - Helping users connect to EVM powered networks
 * [REKT](https://rekt.news/leaderboard/) - Rekt News is a leading online platform offering timely and concise information on decentralized finance (DeFi), blockchain, and the cryptocurrency industry
 ## Web3Auditors Companies

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ List links and description
 * [Damn Vulnerable DeFi](https://www.damnvulnerabledefi.xyz/) - The training ground for security researchers, developers and educators to dive into smart contract security.
 * [The Ethernaut](https://ethernaut.openzeppelin.com/) - The Ethernaut is a Web3/Solidity based wargame inspired by overthewire.org
 ## Playgrounds
-* [Remix Ethereum](https://remix.ethereum.org/) - No more words.Everybody knows Remix 
+* [Remix Ethereum](https://remix.ethereum.org/) - No more words. Everybody knows Remix 
 ## Standards
 * [ERC 20](https://ethereum.org/en/developers/docs/standards/tokens/erc-20/) - The ERC-20 introduces a standard for Fungible Tokens, in other words, they have a property that makes each Token be exactly the same (in type and value) as another Token.
 * [OWASP Smart Contract](https://owasp.org/www-project-smart-contract-top-10/) - The OWASP Smart Contract Top 10 is a standard awareness document that intends to provide Web3 developers and security teams with insight into the top 10 vulnerabilities found in smart contracts.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ It is a collection of awesome software, libraries, documents, books, resources, 
 
 Thanks to all [contributors](https://github.com/fabionoth/awesome-web3-security/graphs/contributors). You're awesome. This wouldn't be possible without you! The goal is to build a categorized, community-driven collection of very well-known resources.
 
-
 List links and description 
 
 ## Tools
@@ -42,11 +41,18 @@ List links and description
 ### Other tools
 * [ETH-Toolbox](https://eth-toolbox.com/) - EthToolbox v1.1 is a set of useful tools for Ethereum developers.
 * [dethcode](https://github.com/dethcrypto/dethcode) - View source of deployed Ethereum smart contracts in VS Code
-### Extensions and Formatters
 ## BugBounty
 ## CTF
+* [Damn Vulnerable DeFi](https://www.damnvulnerabledefi.xyz/) - The training ground for security researchers, developers and educators to dive into smart contract security.
+* [blocksec-ctfs](https://github.com/blockthreat/blocksec-ctfs) - A curated list of blockchain security Wargames, Challenges, and Capture the Flag (CTF) competitions and solution writeups.
+* [The Ethernaut](https://ethernaut.openzeppelin.com/) - The Ethernaut is a Web3/Solidity based wargame inspired by overthewire.org
+* [Capture the Ether](https://capturetheether.com/) - the game of Ethereum smart contract security
+* [ciphershastra](https://ciphershastra.com/) - A place where you can enhance your Security Skills by solving and learning from CTF-like challenges.
 ## Playgrounds
-## Genesys Blocks
+* [Remix Ethereum](https://remix.ethereum.org/) - No more words.Everybody knows Remix 
 ## Standards
+* [ERC 20] - (https://ethereum.org/en/developers/docs/standards/tokens/erc-20/) - The ERC-20 introduces a standard for Fungible Tokens, in other words, they have a property that makes each Token be exactly the same (in type and value) as another Token.
+* [OWASP Smart Contract] - (https://owasp.org/www-project-smart-contract-top-10/) - The OWASP Smart Contract Top 10 is a standard awareness document that intends to provide Web3 developers and security teams with insight into the top 10 vulnerabilities found in smart contracts.
 ## Databases
+* [REKT](https://rekt.news/leaderboard/) - Rekt News is a leading online platform offering timely and concise information on decentralized finance (DeFi), blockchain, and the cryptocurrency industry
 ## Web3Auditors Companies

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ List links and description
 * **[Tools](#tools)**
   * [Forensics](#forensics)
   * [Testing](#testing)
+  * [SAST/DAST/Unity Test Analysis](#sast)
+  * [OS](#os)
+  * [Fuzzers](#fuzzers)
 
 ## <a name="tools"></a> Tools
 ### <a name="forensics"> Forensics
@@ -22,7 +25,7 @@ List links and description
 * [Rugscreen](https://rugscreen.com/) - Catches rugpulls before you lose money.
 * [TokenSniffer](https://tokensniffer.com/) - Automated scam detection, auditing, and metrics
 * [Rug PUll Detector](http://rugpulldetector.com/) - Find the smart contract of the token and copy solidity code
-### SAST/DAST/Unity Test Analisys
+### <a name="sast"> SAST/DAST/Unity Test Analysis
 * [Brownie](https://eth-brownie.readthedocs.io/en/stable/) - Brownie is a Python-based development and testing framework for smart contracts targeting the Ethereum Virtual Machine.
 * [Ethereum Security Box](https://github.com/trailofbits/eth-security-toolbox) - This repository contains scripts to create a Docker container preinstalled and preconfigured with all of Trail of Bits’ Ethereum security tools.
 * [Foundry](https://github.com/foundry-rs/foundry) - Foundry is a blazing fast, portable and modular toolkit for Ethereum application development written in Rust.
@@ -37,9 +40,9 @@ List links and description
 * [Surya](https://github.com/ConsenSys/surya) - Surya is an utility tool for smart contract systems. It provides a number of visual outputs and information about the contracts' structure.
 * [SmartCheck](https://github.com/smartdec/smartcheck) - SmartCheck is an extensible static analysis tool for discovering vulnerabilities and other code issues in Ethereum smart contracts written in the Solidity programming language.
 * [Truffle Suite](https://archive.trufflesuite.com/) - The most comprehensive suite of tools for smart contract development
-### OS
+### <a name="os"> OS
 * [ZIION](https://www.ziion.org/) - ZIION is the first open-source, end-to-end, pre-compiled, multi-architecture, multi-protocol blockchain security testing and development solution
-### Fuzzers
+### <a name="fuzzers"> Fuzzers
 * [ChainFuzz](https://github.com/ChainSecurity/ChainFuzz) - ChainFuzz requires a truffle project with correct migration files to fuzz a project.
 * [Echidna](https://github.com/crytic/echidna) - Echidna is a Haskell program designed for fuzzing/property-based testing of Ethereum smart contracts.
 * [Foundry](https://github.com/foundry-rs/foundry) - Foundry is a blazing fast, portable and modular toolkit for Ethereum application development written in Rust.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,12 @@ List links and description
 
 ## Tools
 ### Forensics
+* [DeDaub](https://app.dedaub.com/decompile) - The Dedaub decompiler takes Ethereum Virtual Machine (EVM) bytecode and produces more readable Solidity-like code.
+* [abi-decompiler](https://github.com/Decurity/abi-decompiler) - The purpose of abi-decompiler is to implement a simple tools to recover ABI of EVM smart contracts, including function names.
+* [Panoramix](https://github.com/palkeo/panoramix) -This is an EVM decompiler.
 ### SAST Analysis
 ### OS
+* [ZIION](https://www.ziion.org/) - ZIION is the first open-source, end-to-end, pre-compiled, multi-architecture, multi-protocol blockchain security testing and development solution
 ### Unity Testing
 ### Fuzzers
 ### Extensions and Formatters

--- a/README.md
+++ b/README.md
@@ -33,13 +33,15 @@ List links and description
 * [Ethereum Security Box](https://github.com/trailofbits/eth-security-toolbox) - This repository contains scripts to create a Docker container preinstalled and preconfigured with all of Trail of Bits’ Ethereum security tools.
 * [Manticore](https://github.com/trailofbits/manticore) - Manticore is a symbolic execution tool for the analysis of smart contracts and binaries.
 * [Octopus](https://github.com/FuzzingLabs/octopus) - Octopus is a security analysis framework for WebAssembly module and Blockchain Smart Contract.
+### OS
+* [ZIION](https://www.ziion.org/) - ZIION is the first open-source, end-to-end, pre-compiled, multi-architecture, multi-protocol blockchain security testing and development solution
+### Fuzzers
+* [Echidna](https://github.com/crytic/echidna) - Echidna is a Haskell program designed for fuzzing/property-based testing of Ethereum smart contracts.
+* [Foundry](https://github.com/foundry-rs/foundry) - Foundry is a blazing fast, portable and modular toolkit for Ethereum application development written in Rust.
+* [ChainFuzz](https://github.com/ChainSecurity/ChainFuzz) - ChainFuzz requires a truffle project with correct migration files to fuzz a project.
 ### Other tools
 * [ETH-Toolbox](https://eth-toolbox.com/) - EthToolbox v1.1 is a set of useful tools for Ethereum developers.
 * [dethcode](https://github.com/dethcrypto/dethcode) - View source of deployed Ethereum smart contracts in VS Code
-### OS
-* [ZIION](https://www.ziion.org/) - ZIION is the first open-source, end-to-end, pre-compiled, multi-architecture, multi-protocol blockchain security testing and development solution
-### Unity Testing
-### Fuzzers
 ### Extensions and Formatters
 ## BugBounty
 ## CTF

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ List links and description
 ## <a name="ctf"> CTF
 * [blocksec-ctfs](https://github.com/blockthreat/blocksec-ctfs) - A curated list of blockchain security Wargames, Challenges, and Capture the Flag (CTF) competitions and solution writeups.
 * [Capture the Ether](https://capturetheether.com/) - the game of Ethereum smart contract security
+* [CryptoHack](https://cryptohack.org/) - A free, fun platform for learning modern cryptography
 * [ciphershastra](https://ciphershastra.com/) - A place where you can enhance your Security Skills by solving and learning from CTF-like challenges.
 * [Damn Vulnerable DeFi](https://www.damnvulnerabledefi.xyz/) - The training ground for security researchers, developers and educators to dive into smart contract security.
 * [Hack the TON](https://www.hacktheton.com/) - Hack the TON is a TON based wargame inspired by The Ethernaut, played in the TON Virtual Machine.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ List links and description
   * [SAST/DAST/Unity Test Analysis](#sast)
   * [OS](#os)
   * [Fuzzers](#fuzzers)
+  * [Other tools](#others)
+* **[BugBounty](#bugbounty)**
+* **[CTF](#ctf)**
+* **[Playgrounds](#playgrounds)**
+* **[Standards](#standards)**
+* **[Databases/Books and References](#databases)**
+    
 
 ## <a name="tools"></a> Tools
 ### <a name="forensics"> Forensics
@@ -46,24 +53,24 @@ List links and description
 * [ChainFuzz](https://github.com/ChainSecurity/ChainFuzz) - ChainFuzz requires a truffle project with correct migration files to fuzz a project.
 * [Echidna](https://github.com/crytic/echidna) - Echidna is a Haskell program designed for fuzzing/property-based testing of Ethereum smart contracts.
 * [Foundry](https://github.com/foundry-rs/foundry) - Foundry is a blazing fast, portable and modular toolkit for Ethereum application development written in Rust.
-### Other tools
+### <a name="others"> Other tools
 * [ETH-Toolbox](https://eth-toolbox.com/) - EthToolbox v1.1 is a set of useful tools for Ethereum developers.
 * [dethcode](https://github.com/dethcrypto/dethcode) - View source of deployed Ethereum smart contracts in VS Code
-## BugBounty
+## <a name="bugbounty"> BugBounty
 * [Hacken Proof](https://hackenproof.com/) - Expert web3 bug bounty and crowdsourced audit platform
 * [Immunefi](https://immunefi.com/) - Web3's bug bounty platform
-## CTF
+## <a name="ctf"> CTF
 * [blocksec-ctfs](https://github.com/blockthreat/blocksec-ctfs) - A curated list of blockchain security Wargames, Challenges, and Capture the Flag (CTF) competitions and solution writeups.
 * [Capture the Ether](https://capturetheether.com/) - the game of Ethereum smart contract security
 * [ciphershastra](https://ciphershastra.com/) - A place where you can enhance your Security Skills by solving and learning from CTF-like challenges.
 * [Damn Vulnerable DeFi](https://www.damnvulnerabledefi.xyz/) - The training ground for security researchers, developers and educators to dive into smart contract security.
 * [The Ethernaut](https://ethernaut.openzeppelin.com/) - The Ethernaut is a Web3/Solidity based wargame inspired by overthewire.org
-## Playgrounds
+## <a name="playgrounds"> Playgrounds
 * [Remix Ethereum](https://remix.ethereum.org/) - No more words. Everybody knows Remix 
-## Standards
+## <a name="standards"> Standards
 * [ERC 20](https://ethereum.org/en/developers/docs/standards/tokens/erc-20/) - The ERC-20 introduces a standard for Fungible Tokens, in other words, they have a property that makes each Token be exactly the same (in type and value) as another Token.
 * [OWASP Smart Contract](https://owasp.org/www-project-smart-contract-top-10/) - The OWASP Smart Contract Top 10 is a standard awareness document that intends to provide Web3 developers and security teams with insight into the top 10 vulnerabilities found in smart contracts.
-## Databases/Books and References
+## <a name="databases"> Databases/Books and References
 * [Chainlist](https://chainlist.org/) - Helping users connect to EVM powered networks
 * [REKT](https://rekt.news/leaderboard/) - Rekt News is a leading online platform offering timely and concise information on decentralized finance (DeFi), blockchain, and the cryptocurrency industry
 * [Smart Contract Security Chapter](https://github.com/ethereumbook/ethereumbook/blob/develop/09smart-contracts-security.asciidoc) - Chapter 9 from Ethereum book.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ List links and description
 * [Brownie](https://eth-brownie.readthedocs.io/en/stable/) - Brownie is a Python-based development and testing framework for smart contracts targeting the Ethereum Virtual Machine.
 * [Hardhat](https://hardhat.org/) - Hardhat is a development environment for Ethereum software
 * [Foundry](https://github.com/foundry-rs/foundry) - Foundry is a blazing fast, portable and modular toolkit for Ethereum application development written in Rust.
+* [Scribble](https://github.com/ConsenSys/scribble) - A Solidity runtime verification tool for property-based testing.
 * [Slither](https://github.com/crytic/slither) - Slither is a Solidity & Vyper static analysis framework written in Python3
+* [Surya](https://github.com/ConsenSys/surya) - Surya is an utility tool for smart contract systems. It provides a number of visual outputs and information about the contracts' structure.
 * [SmartCheck](https://github.com/smartdec/smartcheck) - SmartCheck is an extensible static analysis tool for discovering vulnerabilities and other code issues in Ethereum smart contracts written in the Solidity programming language.
 * [Mythril](https://github.com/ConsenSys/mythril) - Mythril is a security analysis tool for EVM bytecode
 * [Mythx](https://mythx.io/) - Create a MythX account, link your Ethereum address, and generate API keys

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ List links and description
 * [Damn Vulnerable DeFi](https://www.damnvulnerabledefi.xyz/) - The training ground for security researchers, developers and educators to dive into smart contract security.
 * [The Ethernaut](https://ethernaut.openzeppelin.com/) - The Ethernaut is a Web3/Solidity based wargame inspired by overthewire.org
 ## <a name="playgrounds"> Playgrounds
-* [Remix Ethereum](https://remix.ethereum.org/) - No more words. Everybody knows Remix 
+* [Remix Ethereum](https://remix.ethereum.org/) - No more words. Everybody knows Remix
+* [Rust Playground](https://play.rust-lang.org/) - The Rust Playground
 ## <a name="standards"> Standards
 * [ERC 20](https://ethereum.org/en/developers/docs/standards/tokens/erc-20/) - The ERC-20 introduces a standard for Fungible Tokens, in other words, they have a property that makes each Token be exactly the same (in type and value) as another Token.
 * [OWASP Smart Contract](https://owasp.org/www-project-smart-contract-top-10/) - The OWASP Smart Contract Top 10 is a standard awareness document that intends to provide Web3 developers and security teams with insight into the top 10 vulnerabilities found in smart contracts.

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ List links and description
 ## Playgrounds
 * [Remix Ethereum](https://remix.ethereum.org/) - No more words.Everybody knows Remix 
 ## Standards
-* [ERC 20] - (https://ethereum.org/en/developers/docs/standards/tokens/erc-20/) - The ERC-20 introduces a standard for Fungible Tokens, in other words, they have a property that makes each Token be exactly the same (in type and value) as another Token.
-* [OWASP Smart Contract] - (https://owasp.org/www-project-smart-contract-top-10/) - The OWASP Smart Contract Top 10 is a standard awareness document that intends to provide Web3 developers and security teams with insight into the top 10 vulnerabilities found in smart contracts.
+* [ERC 20](https://ethereum.org/en/developers/docs/standards/tokens/erc-20/) - The ERC-20 introduces a standard for Fungible Tokens, in other words, they have a property that makes each Token be exactly the same (in type and value) as another Token.
+* [OWASP Smart Contract](https://owasp.org/www-project-smart-contract-top-10/) - The OWASP Smart Contract Top 10 is a standard awareness document that intends to provide Web3 developers and security teams with insight into the top 10 vulnerabilities found in smart contracts.
 ## Databases
 * [REKT](https://rekt.news/leaderboard/) - Rekt News is a leading online platform offering timely and concise information on decentralized finance (DeFi), blockchain, and the cryptocurrency industry
 ## Web3Auditors Companies

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ List links and description
 ### <a name="testing"> Testing
 * [BSCheck](https://bscheck.eu/) - Free Binance Smart Chain token analyzer
 * [QuillCheck](https://check.quillai.network/) - Safeguard your web3 investments with our AI Agent. Uncover honeypots, understand token permissions, and get comprehensive market insights. Shield yourself from rugpulls and scam tokens. DYOR here!
+* [RektRadar](https://rektradar.io/) - Real-time Ethereum scam detector with mempool monitoring, deployer graph analysis, and factory pattern detection. Catches rug pulls mid-broadcast, flags honeypots before liquidity is added.
 * [Rugscreen](https://rugscreen.com/) - Catches rugpulls before you lose money.
 * [TokenSniffer](https://tokensniffer.com/) - Automated scam detection, auditing, and metrics
 * [Rug PUll Detector](http://rugpulldetector.com/) - Find the smart contract of the token and copy solidity code

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ List links and description
 * [QuillCheck](https://check.quillai.network/) - Safeguard your web3 investments with our AI Agent. Uncover honeypots, understand token permissions, and get comprehensive market insights. Shield yourself from rugpulls and scam tokens. DYOR here!
 * [RektRadar](https://rektradar.io/) - Real-time Ethereum scam detector with mempool monitoring, deployer graph analysis, and factory pattern detection. Catches rug pulls mid-broadcast, flags honeypots before liquidity is added.
 * [Rugscreen](https://rugscreen.com/) - Catches rugpulls before you lose money.
+* [Sharpe Rug Check](https://www.sharpe.ai/rug-check) - Live token risk scanner for honeypot, liquidity, holder, ownership, and authority signals.
 * [TokenSniffer](https://tokensniffer.com/) - Automated scam detection, auditing, and metrics
 * [Rug PUll Detector](http://rugpulldetector.com/) - Find the smart contract of the token and copy solidity code
 ### <a name="sast"> SAST/DAST/Unity Test Analysis

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ List links and description
 * [RektRadar](https://rektradar.io/) - Real-time Ethereum scam detector with mempool monitoring, deployer graph analysis, and factory pattern detection. Catches rug pulls mid-broadcast, flags honeypots before liquidity is added.
 * [Rugscreen](https://rugscreen.com/) - Catches rugpulls before you lose money.
 * [Sharpe Rug Check](https://www.sharpe.ai/rug-check) - Live token risk scanner for honeypot, liquidity, holder, ownership, and authority signals.
+* [RugLens](https://mrvlyouknowwho.github.io/ruglens/) - Free open-source honeypot & rug-pull checker for EVM tokens and TON jettons. Live sell simulation, contract flags, holder concentration and liquidity, in-browser with no sign-up. [Source](https://github.com/mrvlyouknowwho/ruglens).
 * [TokenSniffer](https://tokensniffer.com/) - Automated scam detection, auditing, and metrics
 * [Rug PUll Detector](http://rugpulldetector.com/) - Find the smart contract of the token and copy solidity code
 ### <a name="sast"> SAST/DAST/Unity Test Analysis

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ List links and description
 * [RektRadar](https://rektradar.io/) - Real-time Ethereum scam detector with mempool monitoring, deployer graph analysis, and factory pattern detection. Catches rug pulls mid-broadcast, flags honeypots before liquidity is added.
 * [Rugscreen](https://rugscreen.com/) - Catches rugpulls before you lose money.
 * [Sharpe Rug Check](https://www.sharpe.ai/rug-check) - Live token risk scanner for honeypot, liquidity, holder, ownership, and authority signals.
+* [TRONSEC](https://tronsec.io/app/) - Read-only browser security workbench for TRON: wallet scanner, AML heuristics, contract risk signals, transaction decoder, and URL/phishing checks. Open-source: [github.com/jamejohns/tronsec](https://github.com/jamejohns/tronsec).
 * [TokenSniffer](https://tokensniffer.com/) - Automated scam detection, auditing, and metrics
 * [Rug PUll Detector](http://rugpulldetector.com/) - Find the smart contract of the token and copy solidity code
 ### <a name="sast"> SAST/DAST/Unity Test Analysis

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ List links and description
 ## <a name="bugbounty"> BugBounty
 * [Hacken Proof](https://hackenproof.com/) - Expert web3 bug bounty and crowdsourced audit platform
 * [Immunefi](https://immunefi.com/) - Web3's bug bounty platform
+* [Bounty Radar](https://agent.zbang.net/radar/) - Cross-references every Immunefi bug bounty program with the GitHub repos actually in its scope, so you can see which programs pay without KYC, which have Safe Harbor legal protection, and whether the in-scope code has been pushed recently. Free JSON API, [open data](https://github.com/ofirbaranesad-agent/bounty-radar).
 ## <a name="ctf"> CTF
 * [blocksec-ctfs](https://github.com/blockthreat/blocksec-ctfs) - A curated list of blockchain security Wargames, Challenges, and Capture the Flag (CTF) competitions and solution writeups.
 * [Capture the Ether](https://capturetheether.com/) - the game of Ethereum smart contract security

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ List links and description
 * [dethcode](https://github.com/dethcrypto/dethcode) - View source of deployed Ethereum smart contracts in VS Code
 * [GetBlock](https://getblock.io/) - a Blockchain-as-a-Service (BaaS) platform that provides a fast and easy API connection to RPC full nodes for 50+ blockchains.
 * [TWZRD Agent Intel](https://intel.twzrd.xyz) - On-chain trust scoring for AI agent wallets on Solana. MCP server for verifying agent wallet identity and behavioral history before x402 micropayments — identity layer for autonomous AI agents operating in Web3. [MCP](https://intel.twzrd.xyz/mcp)
+* [SafeAgent](https://github.com/Bemosha/safeagent) - Chrome extension that detects clipboard address substitution, unlimited-approval signatures, seed-phrase input forms and typosquatted domains. Detection runs locally, no telemetry, MV3, MIT. [Chrome Web Store](https://chromewebstore.google.com/detail/ofohhhijlkclalcbfckgpinancpdapmh)
 ## <a name="bugbounty"> BugBounty
 * [Hacken Proof](https://hackenproof.com/) - Expert web3 bug bounty and crowdsourced audit platform
 * [Immunefi](https://immunefi.com/) - Web3's bug bounty platform

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ List links and description
 * [ETH-Toolbox](https://eth-toolbox.com/) - EthToolbox v1.1 is a set of useful tools for Ethereum developers.
 * [dethcode](https://github.com/dethcrypto/dethcode) - View source of deployed Ethereum smart contracts in VS Code
 * [GetBlock](https://getblock.io/) - a Blockchain-as-a-Service (BaaS) platform that provides a fast and easy API connection to RPC full nodes for 50+ blockchains.
+* [TWZRD Agent Intel](https://intel.twzrd.xyz) - On-chain trust scoring for AI agent wallets on Solana. MCP server for verifying agent wallet identity and behavioral history before x402 micropayments — identity layer for autonomous AI agents operating in Web3. [MCP](https://intel.twzrd.xyz/mcp)
 ## <a name="bugbounty"> BugBounty
 * [Hacken Proof](https://hackenproof.com/) - Expert web3 bug bounty and crowdsourced audit platform
 * [Immunefi](https://immunefi.com/) - Web3's bug bounty platform

--- a/README.md
+++ b/README.md
@@ -86,5 +86,6 @@ List links and description
 ## <a name="databases"> Databases/Books and References
 * [Chainlist](https://chainlist.org/) - Helping users connect to EVM powered networks
 * [REKT](https://rekt.news/leaderboard/) - Rekt News is a leading online platform offering timely and concise information on decentralized finance (DeFi), blockchain, and the cryptocurrency industry
+* [Telem Incident Feed](https://telem.news/security/incidents) - Running record of DeFi exploits, hacks and rug pulls, one original attributed brief per incident. Free, no login.
 * [Smart Contract Security Chapter](https://github.com/ethereumbook/ethereumbook/blob/develop/09smart-contracts-security.asciidoc) - Chapter 9 from Ethereum book.
 


### PR DESCRIPTION
Adding the Telem Incident Feed to the Complete Collection of Hacks section — a continuously updated record of DeFi exploits, hacks and rug pulls (date, protocol, and an original attributed brief per incident).

I run Telem. It's free — no login, no paywall. A security-only RSS feed is available at https://telem.news/rss/security.xml if useful for the list.

Happy to adjust the entry format if you'd prefer it different.